### PR TITLE
Update epayRequestHandler for better payment flow

### DIFF
--- a/uWebshop.Payment.ePay/ePayPaymentRequestHandler.cs
+++ b/uWebshop.Payment.ePay/ePayPaymentRequestHandler.cs
@@ -39,11 +39,12 @@ namespace uWebshop.Payment.ePay
 			request.Parameters.Add("amount", orderInfo.ChargedAmountInCents.ToString());
 			request.Parameters.Add("orderid", uniqueId);
 
-			request.Parameters.Add("callbackurl", reportUrl);
+			//request.Parameters.Add("callbackurl", reportUrl);
 			request.Parameters.Add("accepturl", reportUrl);
 			request.Parameters.Add("cancelurl", failedUrl);
 			request.Parameters.Add("currency", orderInfo.StoreInfo.Store.CurrencyCultureSymbol);
 			request.Parameters.Add("windowstate", "3");
+			request.Parameters.Add("ownreceipt", "1");
 			request.PaymentUrlBase = url;
 
 			PaymentProviderHelper.SetTransactionId(orderInfo, uniqueId);


### PR DESCRIPTION
Adding ownreceipt=1 and commenting out callbackurl will send the customer directly to the ResponseHandler and avoid duplicate mail send out. A receipt should be set up on the Success page for the customer.
