### PR TITLE
ePay payment provider, MD5, callback

### DIFF
--- a/uWebshop.Payment.ePay/ePayPaymentBase.cs
+++ b/uWebshop.Payment.ePay/ePayPaymentBase.cs
@@ -1,10 +1,29 @@
-﻿namespace uWebshop.Payment.ePay
+﻿using System.Text;
+
+namespace uWebshop.Payment.ePay
 {
-	public class ePayPaymentBase
-	{
-		public string GetName()
-		{
-			return "ePay";
-		}
-	}
+    public class ePayPaymentBase
+    {
+        public string GetName()
+        {
+            return "ePay";
+        }
+
+        public static string MD5(string phrase)
+        {
+            var hasher = System.Security.Cryptography.MD5.Create();
+            var hashedDataBytes = hasher.ComputeHash(Encoding.UTF8.GetBytes(phrase));
+            return ByteArrayToString(hashedDataBytes);
+        }
+
+        private static string ByteArrayToString(byte[] inputArray)
+        {
+            var sb = new StringBuilder();
+            for (var i = 0; i < inputArray.Length; i++)
+            {
+                sb.Append(inputArray[i].ToString("X2"));
+            }
+            return sb.ToString();
+        }
+    }
 }

--- a/uWebshop.Payment.ePay/ePayPaymentProvider.cs
+++ b/uWebshop.Payment.ePay/ePayPaymentProvider.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO;
-using System.Net;
 using uWebshop.Common;
 using uWebshop.Domain;
 using uWebshop.Domain.Interfaces;
@@ -17,16 +15,15 @@ namespace uWebshop.Payment.ePay
 		public IEnumerable<PaymentProviderMethod> GetAllPaymentMethods(int id)
 		{
 			var paymentProviderMethodList = new List<PaymentProviderMethod>
-			                                {
-				                                new PaymentProviderMethod
-				                                {
-					                                Id = "ePay", 
-													ProviderName = GetName(), 
-													Title = "ePay", 
-													Description = "ePay Payment Provider"
-				                                }
-			                                };
-
+			    {
+				    new PaymentProviderMethod
+				    {
+					    Id = "ePay", 
+						ProviderName = GetName(), 
+						Title = "ePay", 
+						Description = "ePay Payment Provider"
+				    }
+			    };
 			return paymentProviderMethodList;
 		}
 	}

--- a/uWebshop.Payment.ePay/ePayPaymentResponseHandler.cs
+++ b/uWebshop.Payment.ePay/ePayPaymentResponseHandler.cs
@@ -6,45 +6,64 @@ using uWebshop.Domain.Interfaces;
 
 namespace uWebshop.Payment.ePay
 {
-	public class ePayPaymentResponseHandler : ePayPaymentBase, IPaymentResponseHandler
-	{
-        public OrderInfo HandlePaymentResponse(PaymentProvider paymentProvider, OrderInfo order)
-		{
-			var orderId = HttpContext.Current.Request.QueryString["orderid"];
-
-			if (paymentProvider == null || string.IsNullOrEmpty(orderId))
-			{
-				return null;
-			}
-		
-			order = OrderHelper.GetOrder(orderId);
-			
-			var localizedPaymentProvider = PaymentProvider.GetPaymentProvider(order.PaymentInfo.Id, order.StoreInfo.Alias);
-
-			var acceptUrl = localizedPaymentProvider.SuccessUrl();
-			var failedUrl = localizedPaymentProvider.ErrorUrl();
-
-			var redirectUrl = failedUrl;
-			
-			var amount = HttpContext.Current.Request.QueryString["amount"];
-
-			if (amount == order.ChargedAmountInCents.ToString())
-			{
-				order.Paid = true;
-				order.Status = OrderStatus.ReadyForDispatch;
-				order.Save();
-
-				redirectUrl = acceptUrl;
-			}
-			else
-			{
-				order.Paid = false;
-				order.Save();
-			}
-			
-			HttpContext.Current.Response.Redirect(redirectUrl);
-
-            return order;
-		}
-	}
+    public class ePayPaymentResponseHandler : ePayPaymentBase, IPaymentResponseHandler
+    {
+        public OrderInfo HandlePaymentResponse(PaymentProvider paymentProvider, OrderInfo orderInfo)
+        {
+            var orderId = HttpContext.Current.Request.QueryString["orderid"] ?? "";
+            var transactionId = HttpContext.Current.Request.QueryString["txnid"] ?? "0";
+            if (paymentProvider == null || string.IsNullOrEmpty(orderId))
+            {
+                return null;
+            }
+            orderInfo = OrderHelper.GetOrder(orderId);
+            if (orderInfo != null)
+            {
+                var localizedPaymentProvider = PaymentProvider.GetPaymentProvider(orderInfo.PaymentInfo.Id, orderInfo.StoreInfo.Alias);
+                var secret = paymentProvider.GetSetting("secret");
+                var amount = HttpContext.Current.Request.QueryString["amount"] ?? "0";
+                var validated = true;
+                if (secret != string.Empty)
+                {
+                    var values = string.Empty;
+                    foreach (var key in HttpContext.Current.Request.QueryString.AllKeys)
+                    {
+                        if (key != "hash")
+                        {
+                            values += HttpContext.Current.Request.QueryString[key];
+                        }
+                    }
+                    var calculated = ePayPaymentBase.MD5(values + secret).ToUpperInvariant();
+                    var incoming = (HttpContext.Current.Request.QueryString["hash"] ?? "").ToUpperInvariant();
+                    validated = calculated == incoming;
+                    if (!validated)
+                    {
+                        //checksum error
+                        Log.Instance.LogError("Payment provider (ePay) error : Orderid " + orderId + " - incoming hash " + incoming + " - calculated hash " + calculated);
+                    }
+                }
+                if (validated && (amount == orderInfo.ChargedAmountInCents.ToString()))
+                {
+                    orderInfo.Paid = true;
+                    orderInfo.Status = OrderStatus.ReadyForDispatch;
+                    orderInfo.Save();
+                }
+                else
+                {
+                    orderInfo.Paid = false;
+                    orderInfo.Status = OrderStatus.PaymentFailed;
+                    orderInfo.Save();
+                    if (validated)
+                    {
+                        //checksum already logged, must be problem with amount
+                        Log.Instance.LogError("Payment provider (ePay) error : Orderid " + orderId + " - incoming amount " + amount.ToString() + " - order amount " + orderInfo.ChargedAmountInCents.ToString());
+                    }
+                }
+                HttpContext.Current.Response.Clear();
+                HttpContext.Current.Response.Write("OK");
+                HttpContext.Current.Response.Flush();
+            }
+            return orderInfo;
+        }
+    }
 }

--- a/uWebshop.Payment.ePay/ePayPaymentResponseHandler.cs
+++ b/uWebshop.Payment.ePay/ePayPaymentResponseHandler.cs
@@ -59,10 +59,10 @@ namespace uWebshop.Payment.ePay
                         Log.Instance.LogError("Payment provider (ePay) error : Orderid " + orderId + " - incoming amount " + amount.ToString() + " - order amount " + orderInfo.ChargedAmountInCents.ToString());
                     }
                 }
-                HttpContext.Current.Response.Clear();
-                HttpContext.Current.Response.Write("OK");
-                HttpContext.Current.Response.Flush();
             }
+            HttpContext.Current.Response.Clear();
+            HttpContext.Current.Response.Write("OK");
+            HttpContext.Current.Response.Flush();
             return orderInfo;
         }
     }


### PR DESCRIPTION
ePay payment provider reworked to do MD5 checksum if "secret" present, as well as splitting callback and success urls to provide safe server-to-server callback even if cardholder aborts after payment window. With error logging to default log.